### PR TITLE
feat: allow updating doctor name in frontend

### DIFF
--- a/frontend/src/components/dashboard/dokter/dokter.css
+++ b/frontend/src/components/dashboard/dokter/dokter.css
@@ -62,6 +62,16 @@
   cursor: pointer;
 }
 
+.btn-edit {
+  padding: 4px 8px;
+  background-color: #ffc107;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-right: 4px;
+}
+
 .btn-hapus {
   padding: 4px 8px;
   background-color: crimson;

--- a/frontend/src/components/dashboard/dokter/dokter.jsx
+++ b/frontend/src/components/dashboard/dokter/dokter.jsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { tampilkan_dokter, tambah_dokter, hapus_dokter } from "../../../services/api";
+import {
+  tampilkan_dokter,
+  tambah_dokter,
+  hapus_dokter,
+  update_dokter,
+} from "../../../services/api";
 import "./dokter.css";
 
 const Dokter = () => {
@@ -45,6 +50,7 @@ const Dokter = () => {
       setForm({ nama: "", maks: "", pagi: 0, siang: 0, malam: 0 });
       getData();
     } catch (err) {
+      console.error(err);
       alert("Gagal menambahkan dokter.");
     }
   };
@@ -55,8 +61,21 @@ const Dokter = () => {
         await hapus_dokter({ id: parseInt(id) });
         getData();
       } catch (err) {
+        console.error(err);
         alert("Gagal menghapus dokter.");
       }
+    }
+  };
+
+  const handleUpdate = async (id, nama) => {
+    const namaBaru = window.prompt("Masukkan nama baru", nama);
+    if (!namaBaru) return;
+    try {
+      await update_dokter({ id: parseInt(id), nama: namaBaru });
+      getData();
+    } catch (err) {
+      console.error(err);
+      alert("Gagal memperbarui nama dokter.");
     }
   };
 
@@ -89,6 +108,12 @@ const Dokter = () => {
               <td>{dokter.siang}</td>
               <td>{dokter.malam}</td>
               <td>
+                <button
+                  className="btn-edit"
+                  onClick={() => handleUpdate(dokter.id, dokter.nama)}
+                >
+                  Edit
+                </button>
                 <button className="btn-hapus" onClick={() => handleDelete(dokter.id)}>
                   Hapus
                 </button>


### PR DESCRIPTION
## Summary
- add edit support to doctor management view
- style edit button for clarity

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: 2 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894ee3e77908324a8e78efa9d57aca4