### PR TITLE
Add back button to dashboard layout

### DIFF
--- a/frontend/src/components/dashboard/dashboard.css
+++ b/frontend/src/components/dashboard/dashboard.css
@@ -12,3 +12,17 @@
   overflow-y: auto;
   transition: margin-left 0.3s;
 }
+
+.back-button {
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #4b5563;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.back-button:hover {
+  background-color: #374151;
+}

--- a/frontend/src/components/dashboard/dashboard.jsx
+++ b/frontend/src/components/dashboard/dashboard.jsx
@@ -1,14 +1,16 @@
 import React from "react";
 import Sidebar from "./sidebar/sidebar";
-import { Outlet } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router-dom";
 import "./dashboard.css";
 import "./dokter/dokter.jsx";
 
 const Dashboard = () => {
+  const navigate = useNavigate();
   return (
     <div className="dashboard-container">
       <Sidebar />
       <main className="dashboard-content">
+        <button className="back-button" onClick={() => navigate("/")}>Back to Landing Page</button>
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/landing page/landingpage.jsx
+++ b/frontend/src/components/landing page/landingpage.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import "./landingpage.css";
 
-export default function LandingPage({ onEnter }) {
+export default function LandingPage() {
   const navigate = useNavigate();
   return (
     <div className="landing-container">

--- a/frontend/src/services/api.jsx
+++ b/frontend/src/services/api.jsx
@@ -1,7 +1,7 @@
 const BASE = "http://localhost:8001/api";
 
 export async function fetchWelcomeName() {
-  const res = await fetch(`${BASE_URL}/tes_get`);
+  const res = await fetch(`${BASE}/tes_get`);
   if (!res.ok) throw new Error("Network response was not ok");
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add a Back to Landing Page button in the dashboard so users can return to the landing page
- style the back button and clean up unused/incorrect variables

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f38e4978832483b221027c087f08